### PR TITLE
イベントのCRUD処理時、全データの再取得ではなくlocalのデータを更新するように修正（#share_kakeibo-21）

### DIFF
--- a/lib/feature/event/presentation/state/event_state.dart
+++ b/lib/feature/event/presentation/state/event_state.dart
@@ -29,6 +29,7 @@ class AsyncEvents extends AsyncNotifier<List<Event>> {
     required String paymentUser,
   }) async {
     final repository = ref.watch(eventRepositoryProvider);
+    final events = state.whenOrNull(data: (data) => data) ?? [];
 
     state = const AsyncLoading();
 
@@ -43,7 +44,21 @@ class AsyncEvents extends AsyncNotifier<List<Event>> {
         currentMonth: currentMonth,
         paymentUser: paymentUser,
       );
-      return readEvent();
+
+      // get処理の回数を減らしたいため、stateにEventを追加
+      events.add(
+        Event(
+          id: '${DateTime.now()}', // 仮のid
+          date: date,
+          price: price,
+          largeCategory: largeCategory,
+          smallCategory: smallCategory,
+          memo: memo,
+          registerDate: currentMonth,
+          paymentUser: paymentUser,
+        ),
+      );
+      return events;
     });
   }
 
@@ -53,6 +68,7 @@ class AsyncEvents extends AsyncNotifier<List<Event>> {
     required String id,
   }) async {
     final repository = ref.watch(eventRepositoryProvider);
+    final events = state.whenOrNull(data: (data) => data) ?? [];
 
     state = const AsyncLoading();
 
@@ -61,7 +77,10 @@ class AsyncEvents extends AsyncNotifier<List<Event>> {
         roomCode: roomCode,
         id: id,
       );
-      return readEvent();
+
+      // get処理の回数を減らしたいため、stateのEventを削除
+      events.removeWhere((element) => element.id == id);
+      return events;
     });
   }
 
@@ -77,6 +96,7 @@ class AsyncEvents extends AsyncNotifier<List<Event>> {
     required String paymentUser,
   }) async {
     final repository = ref.watch(eventRepositoryProvider);
+    final events = state.whenOrNull(data: (data) => data) ?? [];
 
     state = const AsyncLoading();
 
@@ -91,7 +111,23 @@ class AsyncEvents extends AsyncNotifier<List<Event>> {
         currentMonth: currentMonth,
         paymentUser: paymentUser,
       );
-      return readEvent();
+
+      // get処理の回数を減らしたいため、stateにEventを追加
+      final eventList = events
+          .map((element) => element.id == event.id
+              ? Event(
+                  id: event.id,
+                  date: date,
+                  price: price,
+                  largeCategory: event.largeCategory,
+                  smallCategory: smallCategory,
+                  memo: memo,
+                  registerDate: currentMonth,
+                  paymentUser: paymentUser,
+                )
+              : element)
+          .toList();
+      return eventList;
     });
   }
 }


### PR DESCRIPTION
# 関連のissue

- [issueのリンク]

## 対応したこと

- [イベントのCRUD処理時、全データの再取得ではなくlocalのデータを更新するように修正](https://github.com/abe-tk/share_kakeibo/commit/412664090ff667ecad99da868602fbc1c0dccd93)

## キャプチャ・GIF・動画など

- 

## その他・備考

firestoreの読み取り回数5万件(無料枠)を超過していたため、`RESOURCE_EXHAUSTED`エラーが発生していた。

イベントの読取を最小限にする実装が必要
- eventProviderのCRUD処理時、データを再度全て取得し直すのではなく、localのstateのListを変更するようにした
- Brazeプランにした