### PR TITLE
招待コード入力時のエラーハンドリングを追加（#share_kakeibo-22）

### DIFF
--- a/lib/feature/room/data/room_repository_impl.dart
+++ b/lib/feature/room/data/room_repository_impl.dart
@@ -52,7 +52,7 @@ class RoomRepositoryImpl extends RoomRepository {
       rethrow;
     } catch (e) {
       logger.e(e);
-      throw '入力した招待コードのルームが存在しません';
+      rethrow;
     }
   }
 

--- a/lib/feature/room/presentation/page/input_code_page.dart
+++ b/lib/feature/room/presentation/page/input_code_page.dart
@@ -52,9 +52,22 @@ class InputCodePage extends HookConsumerWidget {
                     ownerRoomName.value = await ref
                         .read(roomRepositoryProvider)
                         .readRoomName(roomCode: roomCode.value);
+
+                    // 所属ルームのルームコードでなければ、新しいルームコードに更新
+                    if (roomCode.value == ref.watch(roomCodeProvider).value) {
+                      final snackbar = CustomSnackBar(
+                        context,
+                        msg: '既に【${ownerRoomName.value}】に参加しています',
+                        color: Colors.red,
+                      );
+                      scaffoldMessenger.showSnackBar(snackbar);
+                      return;
+                    }
                     ref.read(userInfoProvider.notifier).updateUser(
-                        uid: ref.watch(uidProvider),
-                        newRoomCode: roomCode.value);
+                          uid: ref.watch(uidProvider),
+                          newRoomCode: roomCode.value,
+                        );
+
                     await ref.read(roomMemberProvider.notifier).joinRoom(
                           roomCode: roomCode.value,
                           userName: userData!.userName,
@@ -73,6 +86,16 @@ class InputCodePage extends HookConsumerWidget {
                     scaffoldMessenger.showSnackBar(snackbar);
                   } catch (e) {
                     logger.e(e.toString());
+                    // 入力したコードでルーム名が読み取れない = 招待コードが存在しない場合
+                    if (ownerRoomName.value.isEmpty) {
+                      final snackbar = CustomSnackBar(
+                        context,
+                        msg: '入力した招待コードのルームが存在しません',
+                        color: Colors.red,
+                      );
+                      scaffoldMessenger.showSnackBar(snackbar);
+                      return;
+                    }
                   }
                 },
               ),


### PR DESCRIPTION
# 関連のissue

- [issueのリンク]

## 対応したこと

- [招待コード入力時のエラーハンドリングを追加](https://github.com/abe-tk/share_kakeibo/commit/3a474d19a72ba3f162a4f9dc7d00cbd63a1886a3)

## キャプチャ・GIF・動画など

- 

## その他・備考

- 